### PR TITLE
Explicitly checking if query_parameters exist, rather than relying on this.roomcast

### DIFF
--- a/nutella-connector.html
+++ b/nutella-connector.html
@@ -71,7 +71,7 @@
             ready: function () {
                 var me = this;
                 // Nutella initialization
-                if( this.roomcast ) {
+                if( query_parameters && query_parameters.app_id ) {
                     var query_parameters = NUTELLA.parseURLParameters();
 
                     console.log('query params: broker', query_parameters.broker);


### PR DESCRIPTION
This addresses #1, and works well for wallcology app - if it also works for your stand-alone app, it should be merged.
